### PR TITLE
Add jacoco test coverage generation on build

### DIFF
--- a/automation/pom.xml
+++ b/automation/pom.xml
@@ -38,6 +38,10 @@
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <inherited>true</inherited>
@@ -93,6 +97,13 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <!-- Jacoco agent -->
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
         </dependency>
     </dependencies>
 </project>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -37,6 +37,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
         </plugins>
         <resources>
             <resource>
@@ -57,6 +61,13 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
+        </dependency>
+
+        <!-- Jacoco agent -->
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
         </dependency>
     </dependencies>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -37,6 +37,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
             <!-- Maven Assembly Plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -129,6 +133,13 @@
         <dependency>
             <groupId>org.wso2.testgrid</groupId>
             <artifactId>org.wso2.testgrid.logging</artifactId>
+        </dependency>
+
+        <!-- Jacoco agent -->
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
         </dependency>
     </dependencies>
 </project>

--- a/dao/pom.xml
+++ b/dao/pom.xml
@@ -36,6 +36,10 @@
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <inherited>true</inherited>
@@ -105,6 +109,13 @@
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <!-- Jacoco agent -->
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
         </dependency>
     </dependencies>
 </project>

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -37,6 +37,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 
@@ -82,6 +86,13 @@
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <!-- Jacoco agent -->
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
         </dependency>
     </dependencies>
 </project>

--- a/infrastructure/pom.xml
+++ b/infrastructure/pom.xml
@@ -37,6 +37,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 
@@ -82,6 +86,13 @@
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <!-- Jacoco agent -->
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
         </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <module>distribution</module>
         <module>web</module>
         <module>logging</module>
+        <module>test/coverage</module>
     </modules>
 
     <scm>
@@ -105,6 +106,59 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>2.5.5</version>
+                </plugin>
+
+                <!-- Maven Jacoco plugin -->
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>${jacoco.version}</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>prepare-agent</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>report</id>
+                            <phase>prepare-package</phase>
+                            <goals>
+                                <goal>report</goal>
+                            </goals>
+                        </execution>
+                        <!-- Specify a minimum coverage ratio. If not met the build will fail -->
+                        <execution>
+                            <id>jacoco-check</id>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                            <configuration>
+                                <rules>
+                                    <rule>
+                                        <element>PACKAGE</element>
+                                        <limits>
+                                            <limit>
+                                                <counter>LINE</counter>
+                                                <value>COVEREDRATIO</value>
+                                                <minimum>0.00</minimum>
+                                            </limit>
+                                        </limits>
+                                    </rule>
+                                </rules>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+
+                <!-- Maven surefire plugin -->
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <inherited>false</inherited>
+                    <configuration>
+                        <systemPropertyVariables>
+                            <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
+                        </systemPropertyVariables>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -186,6 +240,18 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- Plugin dependencies -->
+            <dependency>
+                <groupId>org.jacoco</groupId>
+                <artifactId>org.jacoco.ant</artifactId>
+                <version>${jacoco.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jacoco</groupId>
+                <artifactId>org.jacoco.agent</artifactId>
+                <version>${jacoco.version}</version>
+                <classifier>runtime</classifier>
+            </dependency>
             <!-- Core dependencies -->
             <dependency>
                 <groupId>org.eclipse.jgit</groupId>
@@ -399,6 +465,8 @@
     </dependencyManagement>
 
     <properties>
+        <!-- Plugin versions -->
+        <jacoco.version>0.7.9</jacoco.version>
         <!-- TestGrid version-->
         <test.grid.version>0.9.0-SNAPSHOT</test.grid.version>
         <!-- Test Grid core dependencies -->

--- a/reporting/pom.xml
+++ b/reporting/pom.xml
@@ -35,6 +35,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 
@@ -73,6 +77,13 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <!-- Jacoco agent -->
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
         </dependency>
     </dependencies>
 </project>

--- a/test/coverage/pom.xml
+++ b/test/coverage/pom.xml
@@ -86,52 +86,20 @@
                                         </taskdef>
                                         <jacoco:report>
                                             <executiondata>
-                                                <fileset dir="../../automation/target">
-                                                    <include name="jacoco.exec"/>
-                                                </fileset>
-                                                <fileset dir="../../common/target">
-                                                    <include name="jacoco.exec"/>
-                                                </fileset>
-                                                <fileset dir="../../core/target">
-                                                    <include name="jacoco.exec"/>
-                                                </fileset>
-                                                <fileset dir="../../dao/target">
-                                                    <include name="jacoco.exec"/>
-                                                </fileset>
-                                                <fileset dir="../../deployment/target">
-                                                    <include name="jacoco.exec"/>
-                                                </fileset>
-                                                <fileset dir="../../infrastructure/target">
-                                                    <include name="jacoco.exec"/>
-                                                </fileset>
-                                                <fileset dir="../../reporting/target">
-                                                    <include name="jacoco.exec"/>
-                                                </fileset>
-                                                <fileset dir="../../web/target">
-                                                    <include name="jacoco.exec"/>
+                                                <fileset dir="../..">
+                                                    <include name="**/target/jacoco.exec"/>
                                                 </fileset>
                                             </executiondata>
                                             <structure name="TestGrid Coverage Report">
                                                 <classfiles>
-                                                    <fileset dir="../../automation/target/classes"/>
-                                                    <fileset dir="../../common/target/classes"/>
-                                                    <fileset dir="../../core/target/classes"/>
-                                                    <fileset dir="../../dao/target/classes"/>
-                                                    <fileset dir="../../deployment/target/classes"/>
-                                                    <fileset
-                                                            dir="../../infrastructure/target/classes"/>
-                                                    <fileset dir="../../reporting/target/classes"/>
-                                                    <fileset dir="../../web/target/classes"/>
+                                                    <fileset dir="../..">
+                                                        <include name="**/target/classes/**"/>
+                                                    </fileset>
                                                 </classfiles>
                                                 <sourcefiles encoding="UTF-8">
-                                                    <fileset dir="../../automation/src"/>
-                                                    <fileset dir="../../common/src"/>
-                                                    <fileset dir="../../core/src"/>
-                                                    <fileset dir="../../dao/src"/>
-                                                    <fileset dir="../../deployment/src"/>
-                                                    <fileset dir="../../infrastructure/src"/>
-                                                    <fileset dir="../../reporting/src"/>
-                                                    <fileset dir="../../web/src"/>
+                                                    <fileset dir="../..">
+                                                        <include name="**/src/**"/>
+                                                    </fileset>
                                                 </sourcefiles>
                                             </structure>
                                             <html destdir="${project.build.directory}/site/jacoco"/>

--- a/test/coverage/pom.xml
+++ b/test/coverage/pom.xml
@@ -1,0 +1,155 @@
+<!--
+  ~  Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+  ~
+  ~  WSO2 Inc. licenses this file to you under the Apache License,
+  ~  Version 2.0 (the "License"); you may not use this file except
+  ~  in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <artifactId>testgrid-framework</artifactId>
+        <groupId>org.wso2.testgrid</groupId>
+        <version>0.9.0-SNAPSHOT</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>org.wso2.testgrid.test.coverage</artifactId>
+    <name>WSO2 TestGrid Framework - Test Coverage POM</name>
+    <url>http://wso2.org</url>
+    <dependencies>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.ant</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <profiles>
+        <profile>
+            <id>with-tests</id>
+            <activation>
+                <property>
+                    <name>!maven.test.skip</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-dependency-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>copy-jacoco-dependencies</id>
+                                <phase>compile</phase>
+                                <goals>
+                                    <goal>copy-dependencies</goal>
+                                </goals>
+                                <configuration>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                    <includeTypes>jar</includeTypes>
+                                    <includeArtifactIds>org.jacoco.ant</includeArtifactIds>
+                                    <stripVersion>true</stripVersion>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- Ant plugin - Merge Jacoco Reports -->
+                    <!-- Logging and distribution modules are not checked since not relevant -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target xmlns:jacoco="antlib:org.jacoco.ant">
+                                        <taskdef uri="antlib:org.jacoco.ant"
+                                                 resource="org/jacoco/ant/antlib.xml">
+                                            <classpath path="${project.build.directory}"/>
+                                        </taskdef>
+                                        <jacoco:report>
+                                            <executiondata>
+                                                <fileset dir="../../automation/target">
+                                                    <include name="jacoco.exec"/>
+                                                </fileset>
+                                                <fileset dir="../../common/target">
+                                                    <include name="jacoco.exec"/>
+                                                </fileset>
+                                                <fileset dir="../../core/target">
+                                                    <include name="jacoco.exec"/>
+                                                </fileset>
+                                                <fileset dir="../../dao/target">
+                                                    <include name="jacoco.exec"/>
+                                                </fileset>
+                                                <fileset dir="../../deployment/target">
+                                                    <include name="jacoco.exec"/>
+                                                </fileset>
+                                                <fileset dir="../../infrastructure/target">
+                                                    <include name="jacoco.exec"/>
+                                                </fileset>
+                                                <fileset dir="../../reporting/target">
+                                                    <include name="jacoco.exec"/>
+                                                </fileset>
+                                                <fileset dir="../../web/target">
+                                                    <include name="jacoco.exec"/>
+                                                </fileset>
+                                            </executiondata>
+                                            <structure name="TestGrid Coverage Report">
+                                                <classfiles>
+                                                    <fileset dir="../../automation/target/classes"/>
+                                                    <fileset dir="../../common/target/classes"/>
+                                                    <fileset dir="../../core/target/classes"/>
+                                                    <fileset dir="../../dao/target/classes"/>
+                                                    <fileset dir="../../deployment/target/classes"/>
+                                                    <fileset
+                                                            dir="../../infrastructure/target/classes"/>
+                                                    <fileset dir="../../reporting/target/classes"/>
+                                                    <fileset dir="../../web/target/classes"/>
+                                                </classfiles>
+                                                <sourcefiles encoding="UTF-8">
+                                                    <fileset dir="../../automation/src"/>
+                                                    <fileset dir="../../common/src"/>
+                                                    <fileset dir="../../core/src"/>
+                                                    <fileset dir="../../dao/src"/>
+                                                    <fileset dir="../../deployment/src"/>
+                                                    <fileset dir="../../infrastructure/src"/>
+                                                    <fileset dir="../../reporting/src"/>
+                                                    <fileset dir="../../web/src"/>
+                                                </sourcefiles>
+                                            </structure>
+                                            <html destdir="${project.build.directory}/site/jacoco"/>
+                                        </jacoco:report>
+                                    </target>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.jacoco</groupId>
+                                <artifactId>org.jacoco.ant</artifactId>
+                                <version>${jacoco.version}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -85,6 +85,13 @@
             <groupId>org.wso2.testgrid</groupId>
             <artifactId>org.wso2.testgrid.logging</artifactId>
         </dependency>
+
+        <!-- Jacoco agent -->
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+        </dependency>
     </dependencies>
 
     <build>
@@ -94,10 +101,10 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
-                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
                 </plugin>
                 <plugin>
                     <artifactId>maven-war-plugin</artifactId>


### PR DESCRIPTION
## Purpose
Resolves #48 
Jacoco test coverage report generation implemented

## Goals
Generate test coverage report for TestGrid during build

## Release note
* Add Jacoco test coverage report generation

## Automation tests
 - Unit tests 
   > N/A - Test coverage report generation
 - Integration tests
   > N/A - Test coverage report generation

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes