### PR TITLE
Fix incorrect log file path and name in Jenkins environment 

### DIFF
--- a/distribution/bin/log4j2.xml
+++ b/distribution/bin/log4j2.xml
@@ -38,7 +38,7 @@
         </RollingFile>
 
         <Routing name="Routing">
-            <Routes pattern="$${path:key2}">
+            <Routes pattern="${path:key2}">
                 <Route>
                     <RollingFile name="SCENARIO_LOGFILE" fileName="${env:TESTGRID_HOME}/${path:key2}.log"
                                  filePattern="${env:TESTGRID_HOME}/${path:key2}-%d{MM-dd-yyyy}-%i.log">


### PR DESCRIPTION
Please note that this PR is dependant on PR https://github.com/wso2-incubator/testgrid/pull/307

## Purpose
Correct the log file path and name.

Resolves #323 

## Release note
* Incorrect log file path and location in Jenkins environment corrected.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes