### PR TITLE
Fix dashboard error message display restrictions 

### DIFF
--- a/web/src/main/react-dashboard/src/App.js
+++ b/web/src/main/react-dashboard/src/App.js
@@ -68,7 +68,7 @@ class App extends Component {
   }
 
   render() {
-    const paperStyle = { margin: '26px 40px 50px ' + this.state.navWidth + 'px' };
+    const paperStyle = { margin: '80px 40px 50px ' + this.state.navWidth + 'px' };
     return (
       <Provider store={store}>
         <PersistGate
@@ -76,7 +76,7 @@ class App extends Component {
           <MuiThemeProvider>
             <div style={{ position: 'absolute', top: '0px', right: '0px', bottom: '0px', left: '0px', backgroundColor: '#EEEEEE' }}>
               <AppBar title=" WSO2 TestGrid " style={{
-                backgroundColor: '#424242',
+                backgroundColor: '#424242',position: 'fixed'
               }}
                 iconElementLeft={<IconButton onClick={this.handleClose}>{this.state.open ? <NavigationBack /> : <NevigationExpand />}</IconButton>}
                 iconElementRight={<FlatButton label="Login" />} > </AppBar>

--- a/web/src/main/react-dashboard/src/components/TestCaseView.js
+++ b/web/src/main/react-dashboard/src/components/TestCaseView.js
@@ -83,7 +83,10 @@ class TestCaseView extends Component {
                                 <TableRowColumn>
                                     <h4>{data.name}</h4></TableRowColumn>
                                 <TableRowColumn><SingleRecord value={data.success} /></TableRowColumn>
-                                <TableRowColumn style={{ color: 'red' }}>
+                                <TableRowColumn style={{
+                                    color: 'red', whiteSpace: 'normal',
+                                    wordWrap: 'break-word'
+                                }}>
                                     <h4>{data.errorMsg}</h4></TableRowColumn>
                             </TableRow>)
                         })}

--- a/web/src/main/react-dashboard/src/components/TestCaseView.js
+++ b/web/src/main/react-dashboard/src/components/TestCaseView.js
@@ -84,7 +84,8 @@ class TestCaseView extends Component {
                                     <h4>{data.name}</h4></TableRowColumn>
                                 <TableRowColumn><SingleRecord value={data.success} /></TableRowColumn>
                                 <TableRowColumn style={{
-                                    color: 'red', whiteSpace: 'normal',
+                                    color: 'red',
+                                    whiteSpace: 'normal',
                                     wordWrap: 'break-word'
                                 }}>
                                     <h4>{data.errorMsg}</h4></TableRowColumn>


### PR DESCRIPTION
## Purpose
Resolves #330 

## Goals
Change style of dashboard table to show the complete content of error message.

## Approach
Used CSS property `wordWrap:break-word`

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes
