### PR TITLE
Fix logs related to test execution is not persisted in the correct location

### DIFF
--- a/core/src/main/java/org/wso2/testgrid/core/command/RunTestPlanCommand.java
+++ b/core/src/main/java/org/wso2/testgrid/core/command/RunTestPlanCommand.java
@@ -48,7 +48,6 @@ import org.wso2.testgrid.reporting.TestReportEngine;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -65,14 +64,8 @@ import java.util.Optional;
  */
 public class RunTestPlanCommand implements Command {
 
-    private static final String YAML_EXTENSION = ".yaml";
     private static final Logger logger = LoggerFactory.getLogger(RunTestPlanCommand.class);
 
-    @Option(name = "--testplan",
-            usage = "Path to Test plan",
-            aliases = {"-t"},
-            required = true)
-    private String testPlanLocation = "";
     @Option(name = "--product",
             usage = "Product Name",
             aliases = {"-p"},
@@ -103,23 +96,11 @@ public class RunTestPlanCommand implements Command {
     @Override
     public void execute() throws CommandExecutionException {
         try {
-            logger.info("Running the test plan: " + testPlanLocation);
-            if (StringUtil.isStringNullOrEmpty(testPlanLocation) || !testPlanLocation.endsWith(YAML_EXTENSION)) {
-                throw new CommandExecutionException(StringUtil.concatStrings("Invalid test plan location path - ",
-                        testPlanLocation, ". Test plan path location should point to a ", YAML_EXTENSION, " file"));
-            }
-            Path testPlanPath = Paths.get(testPlanLocation);
-            if (!Files.exists(testPlanPath)) {
-                throw new CommandExecutionException(StringUtil.concatStrings("The test plan path does not exist: ",
-                        testPlanPath.toAbsolutePath()));
-            }
             logger.debug(
                     "Input Arguments: \n" +
                     "\tProduct name: " + productName + "\n" +
                     "\tProduct version: " + productVersion + "\n" +
                     "\tChannel" + channel);
-            logger.debug("TestPlan contents : \n" + new String(Files.readAllBytes(testPlanPath),
-                    Charset.forName("UTF-8")));
 
             // Get test plan YAML file path location
             Product product = getProduct(productName, productVersion, channel);

--- a/distribution/bin/log4j2.xml
+++ b/distribution/bin/log4j2.xml
@@ -17,7 +17,7 @@
   ~ under the License.
   ~
   -->
-<Configuration>
+<Configuration packages="org.wso2.testgrid.logging" status="INFO">
     <Appenders>
         <Console name="TESTGRID_CONSOLE" target="SYSTEM_OUT">
             <PatternLayout pattern="[%d] %5p {%c} - %m%ex%n"/>
@@ -38,7 +38,7 @@
         </RollingFile>
 
         <Routing name="Routing">
-            <Routes pattern="${path:key2}">
+            <Routes pattern="$${path:key2}">
                 <Route>
                     <RollingFile name="SCENARIO_LOGFILE" fileName="${env:TESTGRID_HOME}/${path:key2}.log"
                                  filePattern="${env:TESTGRID_HOME}/${path:key2}-%d{MM-dd-yyyy}-%i.log">


### PR DESCRIPTION
## Purpose
Fixes logs related to testing execution not stored in the correct file path with the correct file name.
Resolves #323

## Release note
* Fixed logs related to testing execution not stored in the correct file path with the correct file name.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes